### PR TITLE
Fix/remove-unnecessary-memo-results-grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 This project is built using Next.js and provides dynamic data searching capabilities, including query and filter options to refine the search results. It exposes two main APIs for fetching metadata and performing searches based on various parameters.
 
-There is working deployment of the project hosted on Vercel, Every commit updates the deploment.
+There is working deployment of the project hosted on Vercel, Every succeful PR updates the deploment.
 
 https://finder-mocha.vercel.app/
 
 ## Table of Contents
 
 - [Installation](#installation)
-- [Usage](#usage)
-- [API](#api)
+- [Usage](#Getting started)
+- [API](#APIs)
   - [/api/meta](#apimeta)
   - [/api/search](#apisearch)
 

--- a/components/result-grid/result-grid.tsx
+++ b/components/result-grid/result-grid.tsx
@@ -96,4 +96,4 @@ const ResultsGridComponent: React.FC = () => {
   );
 };
 
-export const ResultsGrid = memo(ResultsGridComponent);
+export const ResultsGrid = ResultsGridComponent;

--- a/fake-data-generator.js
+++ b/fake-data-generator.js
@@ -209,7 +209,7 @@ const generateDummyData = (count) => {
   return dummyDataArray;
 };
 
-const dummyDataArray = generateDummyData(5000); // Change the count to the desired number of dummy data documents
+const dummyDataArray = generateDummyData(1000); // Change the count to the desired number of dummy data documents
 
 const jsonData = JSON.stringify(dummyDataArray, null, 2);
 fs.writeFileSync("dummy_data.json", jsonData);


### PR DESCRIPTION
A unnecessary memo remained in the results grid component, which was not removed after the stores were introduced.